### PR TITLE
Block screenshots by default

### DIFF
--- a/app/src/main/java/com/michaeltroger/gruenerpass/MainActivity.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/MainActivity.kt
@@ -140,6 +140,7 @@ class MainActivity : AppCompatActivity(R.layout.activity_main), AddFile {
         lifecycleScope.launch {
             preferenceUtil.updateScreenBrightness(this@MainActivity)
             preferenceUtil.updateShowOnLockedScreen(this@MainActivity)
+            preferenceUtil.updatePreventScreenshots(this@MainActivity)
         }
     }
 

--- a/app/src/main/java/com/michaeltroger/gruenerpass/settings/PreferenceUtil.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/settings/PreferenceUtil.kt
@@ -36,6 +36,23 @@ class PreferenceUtil @Inject constructor(
         }
     }
 
+    suspend fun updatePreventScreenshots(activity: Activity) {
+        val preventScreenshots = withContext(Dispatchers.IO) {
+            preferenceManager.getBoolean(
+                context.getString(R.string.key_preference_prevent_screenshots),
+                true
+            )
+        }
+
+        activity.window.apply {
+            if (preventScreenshots) {
+                addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            } else {
+                clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            }
+        }
+    }
+
     suspend fun updateShowOnLockedScreen(activity: Activity) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             val showOnLockedScreen = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/michaeltroger/gruenerpass/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/michaeltroger/gruenerpass/settings/SettingsFragment.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.preference.DropDownPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
 import com.michaeltroger.gruenerpass.R
 import com.michaeltroger.gruenerpass.cache.BitmapCache
 import com.michaeltroger.gruenerpass.lock.AppLockedRepo
@@ -32,6 +33,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         setupBarcodeSetting()
         setupLockscreenSetting()
         setupBrightnessSetting()
+        setupPreventScreenshotsSetting()
     }
 
     private fun setupBarcodeSetting() {
@@ -53,6 +55,19 @@ class SettingsFragment : PreferenceFragmentCompat() {
         preference.setOnPreferenceClickListener {
             lifecycleScope.launch {
                 preferenceUtil.updateScreenBrightness(requireActivity())
+            }
+            true
+        }
+    }
+
+    private fun setupPreventScreenshotsSetting() {
+        val preference = findPreference<Preference>(
+            getString(R.string.key_preference_prevent_screenshots)
+        ) ?: error("Preference is required")
+
+        preference.setOnPreferenceClickListener {
+            lifecycleScope.launch {
+                preferenceUtil.updatePreventScreenshots(requireActivity())
             }
             true
         }
@@ -85,6 +100,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
             preference.isVisible = true
         }
 
+        val preventScreenshotsPreference = findPreference<SwitchPreference>(
+            getString(R.string.key_preference_prevent_screenshots)
+        ) ?: error("Preference is required")
+        if (!preference.isChecked) {
+            preventScreenshotsPreference.isEnabled = true
+        }
+
         preference.apply {
             setOnPreferenceClickListener {
                 BiometricPrompt(
@@ -105,6 +127,20 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 requireActivity().onUserInteraction()
                 lockedRepo.unlockApp()
                 preference.isChecked = !preference.isChecked
+
+                val preventScreenshotsPreference = findPreference<SwitchPreference>(
+                    getString(R.string.key_preference_prevent_screenshots)
+                ) ?: error("Preference is required")
+
+                if (preference.isChecked) {
+                    preventScreenshotsPreference.isChecked = true
+                    preventScreenshotsPreference.isEnabled = false
+                    lifecycleScope.launch {
+                        preferenceUtil.updatePreventScreenshots(requireActivity())
+                    }
+                } else {
+                    preventScreenshotsPreference.isEnabled = true
+                }
             }
         }
     }

--- a/app/src/main/res/drawable/screenshot_24.xml
+++ b/app/src/main/res/drawable/screenshot_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSecondary">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M17,1.01L7,1C5.9,1 5,1.9 5,3v18c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V3C19,1.9 18.1,1.01 17,1.01zM17,18H7V6h10V18zM9.5,8.5H12V7H8v4h1.5V8.5zM12,17h4v-4h-1.5v2.5H12V17z"/>
+</vector>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -31,4 +31,5 @@
     <string name="key_preference_barcodes_disabled">disabled</string>
     <string name="key_preference_barcodes_regular">regular</string>
     <string name="key_preference_barcodes_extended">extended</string>
+    <string name="key_preference_prevent_screenshots">preventScreenshots</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,4 +63,6 @@
     <string name="preference_barcode_disabled">Disabled</string>
     <string name="preference_barcode_regular">Regular intensity</string>
     <string name="preference_barcode_extended">Extended (best possible detection)</string>
+    <string name="preference_prevent_screenshots">Prevent screenshots</string>
+    <string name="preference_prevent_screenshots_description">Can\'t be disabled when authentication is enabled.</string>
 </resources>

--- a/app/src/main/res/xml/preference.xml
+++ b/app/src/main/res/xml/preference.xml
@@ -49,4 +49,12 @@
         android:defaultValue="false"
         app:isPreferenceVisible="false"
         tools:isPreferenceVisible="true"/>
+
+    <SwitchPreference
+        android:key="@string/key_preference_prevent_screenshots"
+        android:icon="@drawable/screenshot_24"
+        android:title="@string/preference_prevent_screenshots"
+        android:summary="@string/preference_prevent_screenshots_description"
+        android:defaultValue="true"
+        android:enabled="false"/>
 </PreferenceScreen>


### PR DESCRIPTION
Fixes a security issue: When authentication was enabled and the app got locked while in the background, the document content was still readable in "recent apps" view.
The fix is achieved by blocking screenshots in general. Blocking screenshots can only be disabled when authentication isn't enabled.

Blocking screenshots means on Android that the app content will be hidden from "recent apps" view - it's the same setting.


