### PR TITLE
Remove Amazon and Huawei App stores

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -8,19 +8,8 @@ on:
         required: true
         type: boolean
         default: true
-      upload_to_huawei:
-        description: "Upload to Huawei AppGallery"
-        required: true
-        type: boolean
-        default: true
-      upload_to_amazon:
-        description: "Upload to Amazon Appstore"
-        required: true
-        type: boolean
-        default: true
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     env:
@@ -76,7 +65,7 @@ jobs:
         artifactErrorsFailBuild: true
 
     - name: Setup Ruby
-      if: ${{ inputs.upload_to_amazon || inputs.upload_to_google || inputs.upload_to_huawei }}
+      if: ${{ inputs.upload_to_google }}
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
@@ -86,20 +75,6 @@ jobs:
       run: bundle exec fastlane google
       env:
         PLAY_STORE_CREDENTIALS: ${{ secrets.PLAY_STORE_CREDENTIALS }}
-
-    - name: Upload app to Huawei AppGallery
-      if: ${{ inputs.upload_to_huawei }}
-      run: bundle exec fastlane huawei
-      env:
-        HUAWEI_CLIENT_ID: ${{ secrets.HUAWEI_CLIENT_ID }}
-        HUAWEI_CLIENT_SECRET: ${{ secrets.HUAWEI_CLIENT_SECRET }}
-
-    - name: Upload app to Amazon Appstore
-      if: ${{ inputs.upload_to_amazon }}
-      run: bundle exec fastlane amazon
-      env:
-        AMAZON_CLIENT_ID: ${{ secrets.AMAZON_CLIENT_ID }}
-        AMAZON_CLIENT_SECRET: ${{ secrets.AMAZON_CLIENT_SECRET }}
 
     - name: Upload test reports
       uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Get it on:
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
     alt="Get it on F-Droid"
     height="80">](https://f-droid.org/packages/com.michaeltroger.gruenerpass)
-
-[<img src="https://images-na.ssl-images-amazon.com/images/G/01/mobile-apps/devportal2/res/images/amazon-appstore-badge-english-black.png"
-    alt="Available at Amazon Appstore" height="55">](http://www.amazon.com/gp/mas/dl/android?p=com.michaeltroger.gruenerpass)
-[<img src="https://developer.huawei.com/consumer/cn/service/josp/csp/activity/img/Badge-Black.9d53c6f4.png"
-    alt="Explore it on Huawei AppGallery" height="55">](https://appgallery.huawei.com/app/C108212859)
     
 __or directly from [GitHub Releases](https://github.com/michaeltroger/greenpass-android/releases)__
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,23 +9,3 @@ lane :google do
       track: "internal",
     )
 end
-
-lane :huawei do
-    huawei_appgallery_connect(
-        client_id: ENV["HUAWEI_CLIENT_ID"],
-        client_secret: ENV["HUAWEI_CLIENT_SECRET"],
-        app_id: "108212859",
-        apk_path: ENV["AAB_FILE"],
-        is_aab: true,
-        submit_for_review: false,
-    )
-end
-
-lane :amazon do
-    upload_to_amazon_appstore(
-      client_id: ENV["AMAZON_CLIENT_ID"],
-      client_secret: ENV["AMAZON_CLIENT_SECRET"],
-      apk: ENV["APK_FILE"],
-      changes_not_sent_for_review: true,
-    )
-end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -1,2 +1,0 @@
-gem 'fastlane-plugin-huawei_appgallery_connect'
-gem 'fastlane-plugin-amazon_appstore'


### PR DESCRIPTION
The app will no longer be published on Amazon AppStore and Huawei AppGallery.
The goal is to save resources and focus on Google Play and F-Droid only.

In both stores, Huawei and Amazon, the app got only around 100 downloads a year each. Literally 0 reviews.
So it was just not worth it to keep maintaining them.

If you read this as one of the few users affected, then please switch to the F-Droid or Google Play store app. The F-Droid app runs on every Android phone, even without Google Services. It should work fine on your Amazon or Huawei device.